### PR TITLE
Error managing some dates without milliseconds

### DIFF
--- a/scihub.py
+++ b/scihub.py
@@ -91,8 +91,8 @@ scihub configuration file, such as:
 ''' % sys.argv[0]
 
 def isodate(date):
-    iso, ignore = date.replace('T',' ').replace('Z','').split('.')
-    return iso
+    iso, ignore = date.replace('T',' ').replace('Z','')
+    return iso[0:19]
 
 searchbase = 'https://scihub.esa.int/dhus/search'
 servicebase = 'https://scihub.esa.int/dhus/odata/v1'


### PR DESCRIPTION
I found out that some dates doesn't have milliseconds in the time format and the program crashes like this:
Traceback (most recent call last):
  File "./scihub.py", line 316, in <module>
    bdate = isodate(product[4])
  File "./scihub.py", line 94, in isodate
    iso, ignore = date.replace('T',' ').replace('Z','').split('.')
ValueError: need more than 1 value to unpack

For example this entry:
ec598b1f-8c13-49d7-b3bf-1055c486a137 S1A_IW_SLC__1SDV_20150917T190525_20150917T190552_007759_00AC96_7041 2015-09-18T02:34:12.978Z POLYGON ((-17.229002 30.334890,-14.634670 30.740238,-14.314926 29.110668,-16.865559 28.702797,-17.229002 30.334890)) 2015-09-17T19:05:25Z 2015-09-17T19:05:52.072Z ASCENDING SLC 7759 162 Sentinel-1

Instead splitting the string iso if the program return first twenty characters seems to solve the problem. Maybe there are better approaches to solve the problem.
