### PR TITLE
Added compatibility with non-debian magic module

### DIFF
--- a/scihub.py
+++ b/scihub.py
@@ -119,9 +119,9 @@ configuration_file = '/usr/local/etc/scihub.cfg'
 try:
     m = magic.open(magic.MAGIC_MIME_TYPE)
     m.load()
-except:
-    print "magic module error, wrong version?"
-    sys.exit(8)
+except AttributeError,e:
+    m = magic.Magic(mime=True)
+    m.file = m.from_file
 
 try:
     opts, args = getopt.getopt(sys.argv[1:],'cvfdhmklD:L:C:o',


### PR DESCRIPTION
Now, if no debian´s phython-magic module is found on the system it will work with python-magic 0.4.x from https://github.com/ahupp/python-magic. This module can be installed within pip with the command:

"pip install python-magic"

Tested on redhat EL7 and works.
